### PR TITLE
added line to install webpack-dev-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,13 @@ Run the following commands:
 $ npm install
 $ webpack-dev-server
 ```
+
+If you get something like:
+
+``sh
+zsh: command not found: webpack-dev-server
+```
+
+You will need to first install `webpack-dev-server` with the following command:
+
+`npm install webpack-dev-server -g`


### PR DESCRIPTION
This repo was linked from Introduction to React article on Horizon

If the student doesn't already have `webpack-dev-server` installed, they'll need to do so (and it may not be obvious how to do that)
